### PR TITLE
Add perl-Digest-SHA as dependency

### DIFF
--- a/rpm/harbour-getiplay.spec
+++ b/rpm/harbour-getiplay.spec
@@ -24,6 +24,7 @@ AutoReq:    0
 Requires:   sailfishsilica-qt5 >= 0.10.9
 Requires:   perl >= 5.8.8
 Requires:   qt5-qtdeclarative-import-xmllistmodel
+Requires:   perl-Digest-SHA
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)

--- a/rpm/harbour-getiplay.yaml
+++ b/rpm/harbour-getiplay.yaml
@@ -47,8 +47,10 @@ Requires:
 #  - perl-XML-Parser >= 2.41
 #  - perl-XML-Simple >= 2.22
 #  - perl-XML-SAX-Expat >= 0.51
-# Requred to allow use of XmlListModel
+# Required to allow use of XmlListModel
   - qt5-qtdeclarative-import-xmllistmodel
+# Required to allow Mojolicious to be used
+  - perl-Digest-SHA
 
 # All installed files
 Files:


### PR DESCRIPTION
Without this, Mojolicious isn't picked up in the local lib, even
if Digest::SHA is installed in the local lib.

Unfortunately, it seems this has to be installed from the
package repositories, rather into local lib, for it to work.
There must be a way to properly bootstrap local lib without it, but
I couldn't figure it out.

[Robin](https://github.com/llewelld/getiplay/issues/40#issue-330975524) confirmed that this addresses the issue.

Closes #40.