### PR TITLE
Add 'All' option alongside national/regional/local

### DIFF
--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -62,6 +62,10 @@ Page {
                         //% "Local"
                         text: qsTrId("getiplay-settings_listtype_local")
                     }
+                    MenuItem {
+                        //% "All"
+                        text: qsTrId("getiplay-settings_listtype_all")
+                    }
                 }
                 //% "Programme lists must be refreshed to take effect"
                 description: qsTrId("getiplay-settings_listtype_description")

--- a/src/refresh.cpp
+++ b/src/refresh.cpp
@@ -97,13 +97,13 @@ void Refresh::setupEnvironment() {
 }
 
 const QString & Refresh::includeTypeToString(Settings::PROGTYPE refreshType) {
-    static const QString types[Settings::PROGTYPE_NUM] = {"national", "regional", "local"};
+    static const QString types[Settings::PROGTYPE_NUM] = {"national", "regional", "local", "national,regional,local"};
 
     return types[qBound((int)0, (int)refreshType, (int)(Settings::PROGTYPE_NUM - 1))];
 }
 
 const QString & Refresh::excludeTypeToString(Settings::PROGTYPE refreshType) {
-    static const QString types[Settings::PROGTYPE_NUM] = {"regional,local", "national,local", "national,regional"};
+    static const QString types[Settings::PROGTYPE_NUM] = {"regional,local", "national,local", "national,regional", ""};
 
     return types[qBound((int)0, (int)refreshType, (int)(Settings::PROGTYPE_NUM - 1))];
 }
@@ -112,6 +112,8 @@ void Refresh::collectArguments () {
     Settings::PROGTYPE refreshType = Settings::getInstance().getRefreshType();
     QString proxy = Settings::getInstance().getProxyUrl();
     bool rebuildCache = Settings::getInstance().getRebuildCache(currentRefresh);
+    QString include = includeTypeToString(refreshType);
+    QString exclude = excludeTypeToString(refreshType);
     arguments.clear();
 
     addArgument("type=" + typeString[currentRefresh]);
@@ -121,10 +123,13 @@ void Refresh::collectArguments () {
     addArgument("nopurge");
     if (rebuildCache) {
         addArgument("cache-rebuild");
-        qDebug() << "Rebuilding cache";
     }
-    addArgument("refresh-include-groups", includeTypeToString(refreshType));
-    addArgument("refresh-exclude-groups", excludeTypeToString(refreshType));
+    if (include != "") {
+        addArgument("refresh-include-groups", include);
+    }
+    if (exclude != "") {
+        addArgument("refresh-exclude-groups", exclude);
+    }
     addArgument("atomicparsley", DIR_BIN "/AtomicParsley");
     addArgument("ffmpeg", DIR_BIN "/ffmpeg");
     addArgument("ffmpeg-loglevel", "info");

--- a/src/settings.h
+++ b/src/settings.h
@@ -30,6 +30,7 @@ public:
         PROGTYPE_NATIONAL,
         PROGTYPE_REGIONAL,
         PROGTYPE_LOCAL,
+        PROGTYPE_ALL,
 
         PROGTYPE_NUM
     };

--- a/translations/harbour-getiplay-de.ts
+++ b/translations/harbour-getiplay-de.ts
@@ -409,40 +409,45 @@
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="getiplay-settings_listtype_description">
+    <message id="getiplay-settings_listtype_all">
         <location filename="../qml/pages/Settings.qml" line="67"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-settings_listtype_description">
+        <location filename="../qml/pages/Settings.qml" line="71"/>
         <source>Programme lists must be refreshed to take effect</source>
         <oldsource>Programme lists must be refreshed for change to take effect.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_proxy">
-        <location filename="../qml/pages/Settings.qml" line="73"/>
+        <location filename="../qml/pages/Settings.qml" line="77"/>
         <source>Web proxy URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_subtitle_file_storage">
-        <location filename="../qml/pages/Settings.qml" line="83"/>
+        <location filename="../qml/pages/Settings.qml" line="87"/>
         <source>File storage settings</source>
         <oldsource>File storage</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="88"/>
+        <location filename="../qml/pages/Settings.qml" line="92"/>
         <source>Video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="99"/>
+        <location filename="../qml/pages/Settings.qml" line="103"/>
         <source>Select video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="110"/>
+        <location filename="../qml/pages/Settings.qml" line="114"/>
         <source>Audio folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="121"/>
+        <location filename="../qml/pages/Settings.qml" line="125"/>
         <source>Select audio folder</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-getiplay-en.ts
+++ b/translations/harbour-getiplay-en.ts
@@ -409,40 +409,45 @@
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="getiplay-settings_listtype_description">
+    <message id="getiplay-settings_listtype_all">
         <location filename="../qml/pages/Settings.qml" line="67"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-settings_listtype_description">
+        <location filename="../qml/pages/Settings.qml" line="71"/>
         <source>Programme lists must be refreshed to take effect</source>
         <oldsource>Programme lists must be refreshed for change to take effect.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_proxy">
-        <location filename="../qml/pages/Settings.qml" line="73"/>
+        <location filename="../qml/pages/Settings.qml" line="77"/>
         <source>Web proxy URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_subtitle_file_storage">
-        <location filename="../qml/pages/Settings.qml" line="83"/>
+        <location filename="../qml/pages/Settings.qml" line="87"/>
         <source>File storage settings</source>
         <oldsource>File storage</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="88"/>
+        <location filename="../qml/pages/Settings.qml" line="92"/>
         <source>Video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="99"/>
+        <location filename="../qml/pages/Settings.qml" line="103"/>
         <source>Select video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="110"/>
+        <location filename="../qml/pages/Settings.qml" line="114"/>
         <source>Audio folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="121"/>
+        <location filename="../qml/pages/Settings.qml" line="125"/>
         <source>Select audio folder</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-getiplay.ts
+++ b/translations/harbour-getiplay.ts
@@ -409,40 +409,45 @@
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="getiplay-settings_listtype_description">
+    <message id="getiplay-settings_listtype_all">
         <location filename="../qml/pages/Settings.qml" line="67"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-settings_listtype_description">
+        <location filename="../qml/pages/Settings.qml" line="71"/>
         <source>Programme lists must be refreshed to take effect</source>
         <oldsource>Programme lists must be refreshed for change to take effect.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_proxy">
-        <location filename="../qml/pages/Settings.qml" line="73"/>
+        <location filename="../qml/pages/Settings.qml" line="77"/>
         <source>Web proxy URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_subtitle_file_storage">
-        <location filename="../qml/pages/Settings.qml" line="83"/>
+        <location filename="../qml/pages/Settings.qml" line="87"/>
         <source>File storage settings</source>
         <oldsource>File storage</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="88"/>
+        <location filename="../qml/pages/Settings.qml" line="92"/>
         <source>Video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="99"/>
+        <location filename="../qml/pages/Settings.qml" line="103"/>
         <source>Select video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="110"/>
+        <location filename="../qml/pages/Settings.qml" line="114"/>
         <source>Audio folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="121"/>
+        <location filename="../qml/pages/Settings.qml" line="125"/>
         <source>Select audio folder</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Previously the refresh type was restricted, so that only one of
national, regional or local programme types could selected at
once. The restriction was for performance reasons (the scrolling
suffered with so many items in th list).

This change adds an 'All' option, allowing all three types to be
refreshed and displayed at once. This is to test performance
again, given the programme has changed a fair bit since this
was last tested, in the hope the performance is now acceptable.