### PR TITLE
Obtain CoverAction image URL correctly

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -31,6 +31,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import QtMultimedia 5.0
+import harbour.getiplay.settings 1.0
 
 CoverBackground {
     id: cover
@@ -145,7 +146,7 @@ CoverBackground {
         enabled: mediaplayerdefined
 
         CoverAction {
-            iconSource: Qt.resolvedUrl("image://getiplay/icon-cover-replay")
+            iconSource: Settings.getImageUrl("icon-cover-replay")
 
             onTriggered: {
                 if (mediaplayerdefined) {

--- a/src/harbour-getiplay.cpp
+++ b/src/harbour-getiplay.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 
     QScopedPointer<QQuickView> view(SailfishApp::createView());
 
-    view->engine()->addImageProvider(QLatin1String("getiplay"), new ImageProvider);
+    view->engine()->addImageProvider(QLatin1String("getiplay"), new ImageProvider(Settings::getInstance()));
     view->setSource(SailfishApp::pathTo("qml/GetiPlay.qml"));
 
     QQmlContext *ctxt = view->rootContext();

--- a/src/imageprovider.cpp
+++ b/src/imageprovider.cpp
@@ -3,32 +3,12 @@
 #include <QPainter>
 #include <QColor>
 #include <QDebug>
-#include <mlite5/MGConfItem>
+#include "settings.h"
 
 #include "imageprovider.h"
 
-ImageProvider::ImageProvider() : QQuickImageProvider(QQuickImageProvider::Pixmap) {
-    QScopedPointer<MGConfItem> ratioItem(new MGConfItem("/desktop/sailfish/silica/theme_pixel_ratio"));
-    pixelRatio = ratioItem->value(1.0).toDouble();
-    QString dir;
-    if (pixelRatio > 1.75) {
-        dir = "2.0";
-    }
-    else if (pixelRatio > 1.5) {
-        dir = "1.75";
-    }
-    else if (pixelRatio > 1.25) {
-        dir = "1.5";
-    }
-    else if (pixelRatio > 1.0) {
-        dir = "1.25";
-    }
-    else {
-        dir = "1.0";
-    }
-
-    imageDir = SailfishApp::pathTo("qml/images/z" + dir).toString(QUrl::RemoveScheme) + "/";
-    qDebug() << "Image folder: " << imageDir;
+ImageProvider::ImageProvider(Settings const & settings) : QQuickImageProvider(QQuickImageProvider::Pixmap) {
+    imageDir = settings.getImageDir();
 }
 
 QPixmap ImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize) {

--- a/src/imageprovider.h
+++ b/src/imageprovider.h
@@ -1,16 +1,16 @@
 #ifndef IMAGEPROVIDER_H
 #define IMAGEPROVIDER_H
 
-#include <sailfishapp.h>
 #include <QQuickImageProvider>
+#include <sailfishapp.h>
+#include "settings.h"
 
 class ImageProvider : public QQuickImageProvider {
 public:
-    explicit ImageProvider();
+    explicit ImageProvider(Settings const & settings);
 
     QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
 private:
-    double pixelRatio;
     QString imageDir;
 };
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,6 +1,8 @@
 #include <QDesktopServices>
 #include <QDateTime>
 #include <QDebug>
+#include <sailfishapp.h>
+#include <mlite5/MGConfItem>
 
 #include "settings.h"
 #include "refresh.h"
@@ -27,6 +29,28 @@ Settings::Settings(QObject *parent) : QObject(parent),
     settings.endArray();
 
     currentTab = settings.value("state/currentTab", 0).toInt();
+
+    QScopedPointer<MGConfItem> ratioItem(new MGConfItem("/desktop/sailfish/silica/theme_pixel_ratio"));
+    pixelRatio = ratioItem->value(1.0).toDouble();
+    QString dir;
+    if (pixelRatio > 1.75) {
+        dir = "2.0";
+    }
+    else if (pixelRatio > 1.5) {
+        dir = "1.75";
+    }
+    else if (pixelRatio > 1.25) {
+        dir = "1.5";
+    }
+    else if (pixelRatio > 1.0) {
+        dir = "1.25";
+    }
+    else {
+        dir = "1.0";
+    }
+
+    imageDir = SailfishApp::pathTo("qml/images/z" + dir).toString(QUrl::RemoveScheme) + "/";
+    qDebug() << "Image folder: " << imageDir;
 }
 
 Settings::~Settings() {
@@ -197,3 +221,11 @@ QString Settings::millisecondsToTime (quint32 milliseconds) {
 
     return QString("%1:%2:%3").arg(hours).arg(minutes, 2, 'f', 0, '0').arg(seconds, 2, 'f', 0, '0');
 }
+
+QString Settings::getImageDir() const {
+    return imageDir;
+}
+QString Settings::getImageUrl(const QString &id) const {
+    return imageDir + id + ".png";
+}
+

--- a/src/settings.h
+++ b/src/settings.h
@@ -60,6 +60,8 @@ public:
     Q_INVOKABLE static QString getTempDir();
     Q_INVOKABLE static QString getLogFile(unsigned int cycle);
     bool getRebuildCache(int type);
+    Q_INVOKABLE QString getImageDir() const;
+    Q_INVOKABLE QString getImageUrl(const QString &id) const;
 
     // Configurable values
     Q_INVOKABLE QString getAudioDir();
@@ -94,6 +96,8 @@ public slots:
 private:
     static Settings * instance;
     QSettings settings;
+    double pixelRatio;
+    QString imageDir;
 
     // Configurable values
     QString audioDir;

--- a/translations/harbour-getiplay-de.ts
+++ b/translations/harbour-getiplay-de.ts
@@ -181,27 +181,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_completed_line1">
-        <location filename="../qml/cover/CoverPage.qml" line="68"/>
+        <location filename="../qml/cover/CoverPage.qml" line="69"/>
         <source>Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_completed_line2">
-        <location filename="../qml/cover/CoverPage.qml" line="70"/>
+        <location filename="../qml/cover/CoverPage.qml" line="71"/>
         <source>Completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_downloading_line1">
-        <location filename="../qml/cover/CoverPage.qml" line="105"/>
+        <location filename="../qml/cover/CoverPage.qml" line="106"/>
         <source>Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_downloading_line2">
-        <location filename="../qml/cover/CoverPage.qml" line="107"/>
+        <location filename="../qml/cover/CoverPage.qml" line="108"/>
         <source>Downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_title">
-        <location filename="../qml/cover/CoverPage.qml" line="132"/>
+        <location filename="../qml/cover/CoverPage.qml" line="133"/>
         <source>GetiPlay</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-getiplay-en.ts
+++ b/translations/harbour-getiplay-en.ts
@@ -4,27 +4,27 @@
 <context>
     <name></name>
     <message id="getiplay-cover_programmes_completed_line1">
-        <location filename="../qml/cover/CoverPage.qml" line="68"/>
+        <location filename="../qml/cover/CoverPage.qml" line="69"/>
         <source>Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_completed_line2">
-        <location filename="../qml/cover/CoverPage.qml" line="70"/>
+        <location filename="../qml/cover/CoverPage.qml" line="71"/>
         <source>Completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_downloading_line1">
-        <location filename="../qml/cover/CoverPage.qml" line="105"/>
+        <location filename="../qml/cover/CoverPage.qml" line="106"/>
         <source>Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_downloading_line2">
-        <location filename="../qml/cover/CoverPage.qml" line="107"/>
+        <location filename="../qml/cover/CoverPage.qml" line="108"/>
         <source>Downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_title">
-        <location filename="../qml/cover/CoverPage.qml" line="132"/>
+        <location filename="../qml/cover/CoverPage.qml" line="133"/>
         <source>GetiPlay</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-getiplay.ts
+++ b/translations/harbour-getiplay.ts
@@ -181,27 +181,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_completed_line1">
-        <location filename="../qml/cover/CoverPage.qml" line="68"/>
+        <location filename="../qml/cover/CoverPage.qml" line="69"/>
         <source>Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_completed_line2">
-        <location filename="../qml/cover/CoverPage.qml" line="70"/>
+        <location filename="../qml/cover/CoverPage.qml" line="71"/>
         <source>Completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_downloading_line1">
-        <location filename="../qml/cover/CoverPage.qml" line="105"/>
+        <location filename="../qml/cover/CoverPage.qml" line="106"/>
         <source>Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_programmes_downloading_line2">
-        <location filename="../qml/cover/CoverPage.qml" line="107"/>
+        <location filename="../qml/cover/CoverPage.qml" line="108"/>
         <source>Downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-cover_title">
-        <location filename="../qml/cover/CoverPage.qml" line="132"/>
+        <location filename="../qml/cover/CoverPage.qml" line="133"/>
         <source>GetiPlay</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
When instantiating the CoverAction, Sailfish doesn't seem to be
able to access the GetiPlay custom QQuickImageProvider, so the
custom image is missing from the 'replay' button.

This change shifts the decision over which directory to get the
images from (based on the pixel ratio of the device being used)
from the image provider and into the settings singleton. The
image provider queries the settings singleton to determine the
folder. As a result, the URL for the CoverAction image can be
extracted from the settings singleton, avoiding the need to query
the (inaccessible) image provider.

Closes #69.