### PR TITLE
All index max connections to be set

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,3 +20,31 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+-----------------------------
+
+Device detection code
+See https://github.com/kimmoli/chargemon/blob/d577d5277e97524a298bea3ff3cec9588971e06b/src/cmon.cpp#L54
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2017 Kimmo Lindholm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -82,6 +82,20 @@ Page {
                 //EnterKey.onClicked: passwordField.focus = true
             }
 
+            Slider {
+                id: indexMaxConn
+                //% "Maximum connections"
+                label: qsTrId("getiplay-settings_max_connections")
+                minimumValue: 1
+                maximumValue: 10
+                value: Settings.indexMaxConn
+                stepSize: 1
+                handleVisible: true
+                valueText: value
+                width: parent.width
+                onValueChanged: Settings.indexMaxConn = value
+            }
+
             SectionHeader {
                 //% "File storage settings"
                 text: qsTrId("getiplay-settings_subtitle_file_storage")

--- a/src/refresh.cpp
+++ b/src/refresh.cpp
@@ -93,6 +93,7 @@ void Refresh::setupEnvironment() {
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     env.insert("PERL5LIB", DIR_PERLLOCAL "/lib/perl5");
     env.insert("PERL_UNICODE", "AS");
+
     process->setProcessEnvironment(env);
 }
 
@@ -130,6 +131,7 @@ void Refresh::collectArguments () {
     if (exclude != "") {
         addArgument("refresh-exclude-groups", exclude);
     }
+    addArgument("index-maxconn", QString("%1").arg(Settings::getInstance().getIndexMaxConn()));
     addArgument("atomicparsley", DIR_BIN "/AtomicParsley");
     addArgument("ffmpeg", DIR_BIN "/ffmpeg");
     addArgument("ffmpeg-loglevel", "info");

--- a/src/settings.h
+++ b/src/settings.h
@@ -24,6 +24,8 @@ class Settings : public QObject
     Q_PROPERTY(PROGTYPE refreshType READ getRefreshType WRITE setRefreshType NOTIFY refreshTypeChanged)
     Q_PROPERTY(unsigned int currentTab READ getCurrentTab WRITE setCurrentTab NOTIFY currentTabChanged)
 
+    Q_PROPERTY(unsigned int indexMaxConn READ getIndexMaxConn WRITE setIndexMaxConn NOTIFY indexMaxConnChanged)
+
 public:
     enum PROGTYPE {
         PROGTYPE_INVALID = -1,
@@ -69,6 +71,7 @@ public:
     Q_INVOKABLE QString getProxyUrl();
     Q_INVOKABLE PROGTYPE getRefreshType();
     Q_INVOKABLE unsigned int getCurrentTab();
+    Q_INVOKABLE unsigned int getIndexMaxConn();
 
     Q_INVOKABLE static QString epochToDate (quint64 epoch);
     Q_INVOKABLE static quint64 dateToEpoch (QString date);
@@ -84,6 +87,7 @@ signals:
     void proxyUrlChanged(QString &proxyUrl);
     void refreshTypeChanged(PROGTYPE refreshType);
     void currentTabChanged(unsigned int currentTab);
+    void indexMaxConnChanged(unsigned int indexMaxConn);
 
 public slots:
     // Configurable values
@@ -92,8 +96,29 @@ public slots:
     void setProxyUrl(QString &value);
     void setRefreshType(PROGTYPE value);
     void setCurrentTab(unsigned int value);
+    void setIndexMaxConn(unsigned int value);
 
 private:
+    typedef enum _DEVICE {
+        DEVICE_INVALID = -1,
+        DEVICE_FAILURE,
+        DEVICE_UNKNOWN,
+
+        DEVICE_JOLLA_ONE,
+        DEVICE_JOLLA_TABLET,
+        DEVICE_ONE_PLUS_X,
+        DEVICE_SIBON,
+        DEVICE_JOLLA_C,
+        DEVICE_AQUAFISH,
+        DEVICE_XPERIA_X,
+        DEVICE_XPERIA_X_DUALSIM,
+        DEVICE_XPERIA_X_COMPACT,
+
+        DEVICe_NUM
+    } DEVICE;
+
+    static DEVICE getDevice();
+
     static Settings * instance;
     QSettings settings;
     double pixelRatio;
@@ -106,6 +131,7 @@ private:
     PROGTYPE refreshType;
     PROGTYPE lastRefreshType[REFRESHTYPE_NUM];
     unsigned int currentTab;
+    unsigned int indexMaxConn;
 };
 
 #endif // SETTINGS_H

--- a/translations/harbour-getiplay-de.ts
+++ b/translations/harbour-getiplay-de.ts
@@ -444,29 +444,34 @@
         <source>Web proxy URL</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="getiplay-settings_max_connections">
+        <location filename="../qml/pages/Settings.qml" line="88"/>
+        <source>Maximum connections</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="getiplay-settings_subtitle_file_storage">
-        <location filename="../qml/pages/Settings.qml" line="87"/>
+        <location filename="../qml/pages/Settings.qml" line="101"/>
         <source>File storage settings</source>
         <oldsource>File storage</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="92"/>
+        <location filename="../qml/pages/Settings.qml" line="106"/>
         <source>Video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="103"/>
+        <location filename="../qml/pages/Settings.qml" line="117"/>
         <source>Select video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="114"/>
+        <location filename="../qml/pages/Settings.qml" line="128"/>
         <source>Audio folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="125"/>
+        <location filename="../qml/pages/Settings.qml" line="139"/>
         <source>Select audio folder</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-getiplay-en.ts
+++ b/translations/harbour-getiplay-en.ts
@@ -444,29 +444,34 @@
         <source>Web proxy URL</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="getiplay-settings_max_connections">
+        <location filename="../qml/pages/Settings.qml" line="88"/>
+        <source>Maximum connections</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="getiplay-settings_subtitle_file_storage">
-        <location filename="../qml/pages/Settings.qml" line="87"/>
+        <location filename="../qml/pages/Settings.qml" line="101"/>
         <source>File storage settings</source>
         <oldsource>File storage</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="92"/>
+        <location filename="../qml/pages/Settings.qml" line="106"/>
         <source>Video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="103"/>
+        <location filename="../qml/pages/Settings.qml" line="117"/>
         <source>Select video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="114"/>
+        <location filename="../qml/pages/Settings.qml" line="128"/>
         <source>Audio folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="125"/>
+        <location filename="../qml/pages/Settings.qml" line="139"/>
         <source>Select audio folder</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-getiplay.ts
+++ b/translations/harbour-getiplay.ts
@@ -444,29 +444,34 @@
         <source>Web proxy URL</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="getiplay-settings_max_connections">
+        <location filename="../qml/pages/Settings.qml" line="88"/>
+        <source>Maximum connections</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="getiplay-settings_subtitle_file_storage">
-        <location filename="../qml/pages/Settings.qml" line="87"/>
+        <location filename="../qml/pages/Settings.qml" line="101"/>
         <source>File storage settings</source>
         <oldsource>File storage</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="92"/>
+        <location filename="../qml/pages/Settings.qml" line="106"/>
         <source>Video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_video_folder">
-        <location filename="../qml/pages/Settings.qml" line="103"/>
+        <location filename="../qml/pages/Settings.qml" line="117"/>
         <source>Select video folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="114"/>
+        <location filename="../qml/pages/Settings.qml" line="128"/>
         <source>Audio folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-settings_select_audio_folder">
-        <location filename="../qml/pages/Settings.qml" line="125"/>
+        <location filename="../qml/pages/Settings.qml" line="139"/>
         <source>Select audio folder</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
When refreshing, Mojolicious generates failure warnings on Jolla One
and Jolla C if the number of simultaneous connections rises above
two. On the Xperia X it seems to be able to handle at least five.

This change makes the maximum number of connections during a refresh
user-configurable. Sensible settings of either 2 or 5 are set for the
devices that it's been tested on (Jolla One, Jolla C, Xperia X).

Closes #61.