### PR TITLE
Correct iterator on deletion

### DIFF
--- a/src/queuemodel.cpp
+++ b/src/queuemodel.cpp
@@ -212,7 +212,9 @@ void QueueModel::pruneQueue() {
         if (((*iter)->getStatus() == Queue::STATUS_LOCAL) && ((*iter)->fileExists() == false)) {
             programmes.erase(iter);
         }
-        iter++;
+        else {
+            iter++;
+        }
     }
 }
 


### PR DESCRIPTION
The iterator should only be increased if the item isn't deleted.
Otherwise the iterator is stepped forwards, and if it's the last
item that happens to be deleted, this will then cause an
exception.

This change fixes this.

Fixes #86.