### PR TITLE
Ensure trimmed log is trimmed to 50 lines

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -49,7 +49,7 @@ void Log::logAppend(const QString &text)
         // Remove excess lines from the top
         while (removeLines > 0) {
             int nextLine = logText.indexOf('\n');
-            if (nextLine > 0) {
+            if (nextLine >= 0) {
                 logText = logText.mid(nextLine + 1);
             }
             removeLines--;
@@ -81,11 +81,30 @@ void Log::importFromFile(QFile & file) {
         logText = in.readAll();
         file.close();
     }
+    qDebug() << "Log lines: " << logText.count('\n');
+    trim();
+    qDebug() << "Trimmed to: " << logText.count('\n');
 }
 
 void Log::clear() {
     logToFile.cycle();
     logText = "";
     emit logTextChanged(logText);
+}
+
+void Log::trim() {
+    int newline;
+    int lines;
+
+    lines = 0;
+    newline = logText.length() - 1;
+    while ((lines <= LOG_LINES) && (newline >= 0)) {
+        newline = logText.lastIndexOf('\n', newline) - 1;
+        lines++;
+    }
+
+    if (newline >= 0) {
+        logText = logText.mid(newline + 2);
+    }
 }
 

--- a/src/log.h
+++ b/src/log.h
@@ -25,6 +25,7 @@ private:
     logfile logToFile;
 
     // Internal methods
+    void trim();
 
 public:
     // General methods


### PR DESCRIPTION
Previously the log file was trimmed to 50 lines each time a new
line was added to it. However, the check was skipped if the
log started with a newline, because the condition for whether a
newline had been found checked for indices greater than zero. It
should have checked for indices that included zero as well. This
has now been fixed.

In addition, the log is trimmed each time it's loaded (which only
happens when the app is started). This addresses the sitation
where the log file is changed outside the program.

Fixes #87.