### PR TITLE
Allow control using lockscreen Mpris controls

### DIFF
--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -15,7 +15,6 @@ Page {
         Rectangle {
             anchors { top: parent.top; left: parent.left; right: parent.right }
             height: parent.height - mainPageHeader.visibleHeight
-            width: parent.width
             clip: true
             antialiasing: false
             color: "transparent"

--- a/qml/pages/QueueItemInfo.qml
+++ b/qml/pages/QueueItemInfo.qml
@@ -173,6 +173,11 @@ Page {
                     anchors.horizontalCenter: parent.horizontalCenter
                     color: "transparent"
 
+                    Label {
+                        id: thumbnailtext
+                        text: ""
+                    }
+
                     Image {
                         visible: true
                         id: thumbnail
@@ -186,23 +191,6 @@ Page {
                         onStatusChanged: {
                             if (status == Image.Ready) {
                                 fadein.start()
-                            }
-                        }
-                    }
-
-                    IconButton {
-                        anchors.verticalCenter: parent.verticalCenter
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        icon.source: Qt.resolvedUrl("image://theme/icon-l-play")
-                        visible: ((qstatus == ProgQueue.STATUS_LOCAL) && (filename != ""))
-
-                        onClicked: {
-                            if (type == Settings.REFRESHTYPE_RADIO) {
-                                startAudio(progId, filename)
-                            }
-                            else {
-                                stopAudio()
-                                pageStack.push(Qt.resolvedUrl("VideoView.qml"), { progId: progId, imageid: imageid, filename: filename })
                             }
                         }
                     }
@@ -236,10 +224,27 @@ Page {
                     spacing: Theme.paddingLarge
 
                     Button {
-                        id: openFile
+                        id: playFile
                         //% "Play"
                         text: qsTrId("getiplay-queueinfo_play")
-                        width: ((parent.width - Theme.paddingLarge) / 2)
+                        width: ((parent.width - 2 * Theme.paddingLarge) / 3)
+                        enabled: ((qstatus == ProgQueue.STATUS_LOCAL) && (filename != ""))
+                        onClicked: {
+                            if (type == Settings.REFRESHTYPE_RADIO) {
+                                startAudio(progId, filename)
+                            }
+                            else {
+                                stopAudio()
+                                pageStack.push(Qt.resolvedUrl("VideoView.qml"), { progId: progId, imageid: imageid, filename: filename })
+                            }
+                        }
+                    }
+
+                    Button {
+                        id: launchFile
+                        //% "Launch"
+                        text: qsTrId("getiplay-queueinfo_launch")
+                        width: ((parent.width - 2 * Theme.paddingLarge) / 3)
                         enabled: ((qstatus == ProgQueue.STATUS_LOCAL) && (filename != ""))
                         onClicked: {
                             Qt.openUrlExternally(filename);
@@ -248,9 +253,9 @@ Page {
 
                     Button {
                         id: visitWebsite
-                        //% "Visit website"
+                        //% "Website"
                         text: qsTrId("getiplay-queueinfo_website")
-                        width: ((parent.width - Theme.paddingLarge) / 2)
+                        width: ((parent.width - 2 * Theme.paddingLarge) / 3)
                         enabled: (web != "")
                         onClicked: Qt.openUrlExternally(web)
                     }

--- a/qml/pages/VideoView.qml
+++ b/qml/pages/VideoView.qml
@@ -27,12 +27,17 @@ Page {
             media.play()
             mediaplayer = media
             mediaplayerdefined = true
+            appwindow.enableControls()
+
+            var playingDetails = Queue.getDetails(progId)
+            mprisPlayer.updateMetadata(playingDetails["name"] + " - " + playingDetails["episode"], playingDetails["channel"])
         }
         else {
             console.log("Record video to play from: " + media.position)
             Queue.setMediaPosition(progId, media.position)
             media.stop()
-            mediaplayerdefined = false
+            appwindow.disableControls()
+            mprisPlayer.updateMetadata("", "")
         }
     }
 

--- a/src/harbour-getiplay.cpp
+++ b/src/harbour-getiplay.cpp
@@ -45,8 +45,6 @@
 int main(int argc, char *argv[])
 {
     int result;
-    QFile file;
-
     // SailfishApp::main() will display "qml/template.qml", if you need more
     // control over initialization, you can use:
     //
@@ -70,37 +68,13 @@ int main(int argc, char *argv[])
     //logfile logs;
 
     QList<ProgModel*> models;
-    ProgModel modelradio;
-    ProgModel modeltv;
-    QueueModel modelqueue;
+    ProgModel modelradio(Settings::getConfigDir() + "/radio.txt");
+    ProgModel modeltv(Settings::getConfigDir() + "/tv.txt");
     models.append(&modelradio);
     models.append(&modeltv);
 
-    file.setFileName(Settings::getConfigDir() + "/radio.txt");
-    modelradio.importFromFile(file);
-    file.setFileName(Settings::getConfigDir() + "/tv.txt");
-    modeltv.importFromFile(file);
-    file.setFileName(Settings::getConfigDir() + "/queue.txt");
-    modelqueue.importFromFile(file);
+    QueueModel modelqueue(Settings::getConfigDir() + "/queue.txt");
     modelqueue.pruneQueue();
-
-    /*
-    QFile file("/opt/sdk/GetiPlay/usr/share/GetiPlay/output01.txt");
-    if (file.open(QIODevice::ReadOnly)) {
-        QRegExp progInfo("^(\\d+):\\t(.*)$");
-        QTextStream in(&file);
-        while (!in.atEnd()) {
-            QString line = in.readLine();
-            int foundPos = progInfo.indexIn(line);
-            if (foundPos > -1) {
-                unsigned int progId = progInfo.cap(1).toUInt();
-                QString title = progInfo.cap(2);
-                model.addProgramme(Programme(progId, title, 0.0));
-            }
-        }
-        file.close();
-    }
-    */
 
     QScopedPointer<QQuickView> view(SailfishApp::createView());
 
@@ -113,21 +87,21 @@ int main(int argc, char *argv[])
     qDebug() << "VERSION_MINOR: " << VERSION_MINOR;
     qDebug() << "VERSION_BUILD: " << VERSION_BUILD;
 
-    QSortFilterProxyModel * proxyModelRadio = new QSortFilterProxyModel ();
+    QSortFilterProxyModel * proxyModelRadio = new QSortFilterProxyModel (view.data());
     proxyModelRadio->setSourceModel(&modelradio);
     proxyModelRadio->setDynamicSortFilter(true);
     proxyModelRadio->setFilterRole(ProgModel::NameRole);
     proxyModelRadio->setFilterCaseSensitivity(Qt::CaseInsensitive);
     proxyModelRadio->setSortCaseSensitivity(Qt::CaseInsensitive);
 
-    QSortFilterProxyModel * proxyModelTV = new QSortFilterProxyModel ();
+    QSortFilterProxyModel * proxyModelTV = new QSortFilterProxyModel (view.data());
     proxyModelTV->setSourceModel(&modeltv);
     proxyModelTV->setDynamicSortFilter(true);
     proxyModelTV->setFilterRole(ProgModel::NameRole);
     proxyModelTV->setFilterCaseSensitivity(Qt::CaseInsensitive);
     proxyModelTV->setSortCaseSensitivity(Qt::CaseInsensitive);
 
-    QSortFilterProxyModel * proxyModelQueue = new QSortFilterProxyModel ();
+    QSortFilterProxyModel * proxyModelQueue = new QSortFilterProxyModel (view.data());
     proxyModelQueue->setSourceModel(&modelqueue);
     proxyModelQueue->setDynamicSortFilter(true);
     proxyModelQueue->setFilterRole(ProgModel::NameRole);
@@ -138,11 +112,8 @@ int main(int argc, char *argv[])
     ctxt->setContextProperty("programmestv", proxyModelTV);
     ctxt->setContextProperty("programmesqueue", proxyModelQueue);
 
-    Log * log = new Log (view.data());
+    Log * log = new Log (Settings::getConfigDir() + "/logtail.txt", view.data());
     view->rootContext()->setContextProperty("Log", log);
-    log->initialise();
-    file.setFileName(Settings::getConfigDir() + "/logtail.txt");
-    log->importFromFile(file);
 
     Refresh * refresh = new Refresh (view.data(), models, log);
     view->rootContext()->setContextProperty("Refresh", refresh);
@@ -167,23 +138,15 @@ int main(int argc, char *argv[])
     // Write out the programme lists
     QDir dir;
     result = dir.mkpath(Settings::getConfigDir());
-    file.setFileName(Settings::getConfigDir() + "/radio.txt");
-    modelradio.exportToFile(file);
-    file.setFileName(Settings::getConfigDir() + "/tv.txt");
-    modeltv.exportToFile(file);
-    file.setFileName(Settings::getConfigDir() + "/queue.txt");
-    modelqueue.exportToFile(file);
-    file.setFileName(Settings::getConfigDir() + "/logtail.txt");
-    log->exportToFile(file);
 
-    delete metaget;
-    delete queue;
-    delete download;
-    delete refresh;
-    delete log;
-    delete proxyModelQueue;
-    delete proxyModelTV;
-    delete proxyModelRadio;
+    //delete metaget;
+    //delete queue;
+    //delete download;
+    //delete refresh;
+    //delete log;
+    //delete proxyModelQueue;
+    //delete proxyModelTV;
+    //delete proxyModelRadio;
 
     return result;
     /*

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,23 +1,32 @@
 #include "log.h"
 #include <QDebug>
 #include "harbour-getiplay.h"
-#include "settings.h"
 
-Log::Log(QObject *parent) :
+Log::Log(QString filename, QObject *parent) :
     QObject(parent),
-    logText("")
+    logText(""),
+    filename(filename)
 {
     logToFile.openLog();
     qDebug() << "LOG FILE OPEN";
-}
 
-void Log::initialise()
-{
+    if (filename != "") {
+        QFile file;
+        file.setFileName(filename);
+        importFromFile(file);
+    }
 }
 
 Log::~Log() {
     logToFile.closeLog();
     qDebug() << "LOG FILE CLOSED";
+
+    if (filename != "") {
+        qDebug() << "Exporting log to: " << filename;
+        QFile file;
+        file.setFileName(filename);
+        exportToFile(file);
+    }
 }
 
 QString Log::getLogText() const

--- a/src/log.h
+++ b/src/log.h
@@ -23,19 +23,18 @@ public:
 private:
     QString logText;
     logfile logToFile;
+    QString filename;
 
     // Internal methods
     void trim();
-
-public:
-    // General methods
-    explicit Log(QObject *parent = 0);
-    ~Log();
-    void initialise();
-    QString getLogText() const;
     void exportToFile(QFile & file);
     void importFromFile(QFile & file);
 
+public:
+    // General methods
+    explicit Log(QString filename = QString(), QObject *parent = 0);
+    ~Log();
+    QString getLogText() const;
     Q_INVOKABLE void logAppend(const QString &text);
     Q_INVOKABLE void logAppendTimestamp(const QString &text);
     Q_INVOKABLE void clear();

--- a/src/progmodel.cpp
+++ b/src/progmodel.cpp
@@ -1,7 +1,8 @@
 #include "progmodel.h"
 #include <QDebug>
 
-ProgModel::ProgModel(QObject *parent) : QAbstractListModel(parent) {
+ProgModel::ProgModel(QString filename, QObject *parent) : QAbstractListModel(parent),
+    filename(filename) {
     roles[ProgIdRole] = "progId";
     roles[EpisodeRole] = "episode";
     roles[DurationRole] = "duration";
@@ -11,6 +12,21 @@ ProgModel::ProgModel(QObject *parent) : QAbstractListModel(parent) {
     roles[NameRole] = "name";
     roles[DescRole] = "description";
     roles[ImageIdRole] = "imageid";
+
+    if (filename != "") {
+        QFile file;
+        file.setFileName(filename);
+        importFromFile(file);
+    }
+}
+
+ProgModel::~ProgModel() {
+    if (filename != "") {
+        qDebug() << "Exporting model to: " << filename;
+        QFile file;
+        file.setFileName(filename);
+        exportToFile(file);
+    }
 }
 
 QHash<int, QByteArray> ProgModel::roleNames() const {

--- a/src/progmodel.h
+++ b/src/progmodel.h
@@ -25,7 +25,8 @@ public:
 
     QHash<int, QByteArray> roleNames() const;
 
-    ProgModel(QObject *parent = 0);
+    ProgModel(QString filename = QString(), QObject *parent = 0);
+    ~ProgModel();
 
     void addProgramme(const Programme &programme);
     void replaceAll(const ProgModel &model);
@@ -36,14 +37,15 @@ public:
 
     void clear();
 
-    void exportToFile(QFile & file);
-    void importFromFile(QFile & file);
-
 signals:
     // General signals
     void programmesChanged();
 
 private:
+    void exportToFile(QFile & file);
+    void importFromFile(QFile & file);
+
+    QString filename;
     QHash<int, QByteArray> roles;
     QList<Programme> programmes;
 };

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1,6 +1,5 @@
 #include <QDebug>
 #include "harbour-getiplay.h"
-#include "settings.h"
 #include "queue.h"
 #include "queueitem.h"
 #include "queuemodel.h"
@@ -231,6 +230,9 @@ QVariant Queue::getDetails(QString progid) {
 
     if (item != nullptr) {
         details.insert("filename", item->getFilename());
+        details.insert("name", item->getName());
+        details.insert("episode", item->getEpisode());
+        details.insert("channel", item->getChannel());
     }
 
     return details;

--- a/src/queuemodel.h
+++ b/src/queuemodel.h
@@ -31,7 +31,8 @@ public:
 
     QHash<int, QByteArray> roleNames() const;
 
-    QueueModel(QObject *parent = 0);
+    QueueModel(QString filename = QString(), QObject *parent = 0);
+    ~QueueModel();
 
     void addProgramme(QueueItem * programme);
     void removeFirstWithProgId(QString progid);
@@ -46,8 +47,6 @@ public:
 
     void clear();
 
-    void exportToFile(QFile & file);
-    void importFromFile(QFile & file);
     void pruneQueue();
     QString removePath(const QString &path);
     void monitorPaths(QFileSystemWatcher &filewatcher);
@@ -58,6 +57,10 @@ signals:
     void programmesChanged();
 
 private:
+    void exportToFile(QFile & file);
+    void importFromFile(QFile & file);
+
+    QString filename;
     QHash<int, QByteArray> roles;
     QList<QueueItem *> programmes;
 };

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -91,6 +91,8 @@ Settings::~Settings() {
     settings.setValue("download/indexMaxConn", indexMaxConn);
     settings.setValue("player/skipTimeShort", skipTimeShort);
     settings.setValue("player/skipTimeLong", skipTimeLong);
+
+    qDebug() << "Settings deleted";
 }
 
 void Settings::instantiate(QObject *parent) {

--- a/translations/harbour-getiplay-de.ts
+++ b/translations/harbour-getiplay-de.ts
@@ -115,85 +115,6 @@
         <source>Deleting file</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="getiplay-queueitem_unqueued">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="50"/>
-        <source>Not queued for download</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_error">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="55"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_remote">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="60"/>
-        <source>Queued for download</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_downloading">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="65"/>
-        <source>Downloading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_local">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="70"/>
-        <source>Downloaded</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_deleted">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="77"/>
-        <source>File deleted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_status_error">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="82"/>
-        <source>Unexpected error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem-title">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="109"/>
-        <source>Queue Item</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_episode">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="127"/>
-        <source>Episode:</source>
-        <oldsource>Episode</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_channel">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="137"/>
-        <source>Channel:</source>
-        <oldsource>Channel</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_date_available">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="147"/>
-        <source>Date:</source>
-        <oldsource>Date</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_date_unknown">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="149"/>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_status">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="159"/>
-        <source>Status:</source>
-        <oldsource>Status</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_play">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="241"/>
-        <source>Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_website">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="252"/>
-        <source>Visit website</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="getiplay-cover_programmes_completed_line1">
         <location filename="../qml/cover/CoverPage.qml" line="69"/>
         <source>Programmes</source>
@@ -290,22 +211,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-proglisttv_title">
-        <location filename="../qml/pages/MainPage.qml" line="40"/>
+        <location filename="../qml/pages/MainPage.qml" line="39"/>
         <source>BBC TV Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-proglistradio_title">
-        <location filename="../qml/pages/MainPage.qml" line="46"/>
+        <location filename="../qml/pages/MainPage.qml" line="45"/>
         <source>BBC Radio Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-queue_title">
-        <location filename="../qml/pages/MainPage.qml" line="52"/>
+        <location filename="../qml/pages/MainPage.qml" line="51"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-log_title">
-        <location filename="../qml/pages/MainPage.qml" line="57"/>
+        <location filename="../qml/pages/MainPage.qml" line="56"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -632,6 +553,91 @@
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message id="getiplay-title">
+        <location filename="../qml/GetiPlay.qml" line="205"/>
+        <source>harbour-getiplay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_unqueued">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="50"/>
+        <source>Not queued for download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_error">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="55"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_remote">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="60"/>
+        <source>Queued for download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_downloading">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="65"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_local">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="70"/>
+        <source>Downloaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_deleted">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="77"/>
+        <source>File deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_status_error">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="82"/>
+        <source>Unexpected error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem-title">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="109"/>
+        <source>Queue Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_episode">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="127"/>
+        <source>Episode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_channel">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="137"/>
+        <source>Channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_date_available">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="147"/>
+        <source>Date:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_date_unknown">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="149"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_status">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="159"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_play">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="229"/>
+        <source>Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_launch">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="246"/>
+        <source>Launch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_website">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="257"/>
+        <source>Website</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-getiplay-en.ts
+++ b/translations/harbour-getiplay-en.ts
@@ -140,85 +140,6 @@
         <source>Deleting file</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="getiplay-queueitem_unqueued">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="50"/>
-        <source>Not queued for download</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_error">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="55"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_remote">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="60"/>
-        <source>Queued for download</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_downloading">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="65"/>
-        <source>Downloading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_local">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="70"/>
-        <source>Downloaded</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_deleted">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="77"/>
-        <source>File deleted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_status_error">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="82"/>
-        <source>Unexpected error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem-title">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="109"/>
-        <source>Queue Item</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_episode">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="127"/>
-        <source>Episode:</source>
-        <oldsource>Episode</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_channel">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="137"/>
-        <source>Channel:</source>
-        <oldsource>Channel</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_date_available">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="147"/>
-        <source>Date:</source>
-        <oldsource>Date</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_date_unknown">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="149"/>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_status">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="159"/>
-        <source>Status:</source>
-        <oldsource>Status</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_play">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="241"/>
-        <source>Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_website">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="252"/>
-        <source>Visit website</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="getiplay-about_title">
         <location filename="../qml/pages/AboutPage.qml" line="28"/>
         <source>About GetiPlay</source>
@@ -290,22 +211,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-proglisttv_title">
-        <location filename="../qml/pages/MainPage.qml" line="40"/>
+        <location filename="../qml/pages/MainPage.qml" line="39"/>
         <source>BBC TV Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-proglistradio_title">
-        <location filename="../qml/pages/MainPage.qml" line="46"/>
+        <location filename="../qml/pages/MainPage.qml" line="45"/>
         <source>BBC Radio Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-queue_title">
-        <location filename="../qml/pages/MainPage.qml" line="52"/>
+        <location filename="../qml/pages/MainPage.qml" line="51"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-log_title">
-        <location filename="../qml/pages/MainPage.qml" line="57"/>
+        <location filename="../qml/pages/MainPage.qml" line="56"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -632,6 +553,91 @@
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message id="getiplay-title">
+        <location filename="../qml/GetiPlay.qml" line="205"/>
+        <source>harbour-getiplay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_unqueued">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="50"/>
+        <source>Not queued for download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_error">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="55"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_remote">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="60"/>
+        <source>Queued for download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_downloading">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="65"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_local">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="70"/>
+        <source>Downloaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_deleted">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="77"/>
+        <source>File deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_status_error">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="82"/>
+        <source>Unexpected error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem-title">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="109"/>
+        <source>Queue Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_episode">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="127"/>
+        <source>Episode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_channel">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="137"/>
+        <source>Channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_date_available">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="147"/>
+        <source>Date:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_date_unknown">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="149"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_status">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="159"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_play">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="229"/>
+        <source>Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_launch">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="246"/>
+        <source>Launch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_website">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="257"/>
+        <source>Website</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-getiplay.ts
+++ b/translations/harbour-getiplay.ts
@@ -115,85 +115,6 @@
         <source>Deleting file</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="getiplay-queueitem_unqueued">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="50"/>
-        <source>Not queued for download</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_error">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="55"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_remote">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="60"/>
-        <source>Queued for download</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_downloading">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="65"/>
-        <source>Downloading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_local">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="70"/>
-        <source>Downloaded</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_deleted">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="77"/>
-        <source>File deleted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_status_error">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="82"/>
-        <source>Unexpected error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem-title">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="109"/>
-        <source>Queue Item</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_episode">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="127"/>
-        <source>Episode:</source>
-        <oldsource>Episode</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_channel">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="137"/>
-        <source>Channel:</source>
-        <oldsource>Channel</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_date_available">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="147"/>
-        <source>Date:</source>
-        <oldsource>Date</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueitem_date_unknown">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="149"/>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_status">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="159"/>
-        <source>Status:</source>
-        <oldsource>Status</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_play">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="241"/>
-        <source>Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="getiplay-queueinfo_website">
-        <location filename="../qml/pages/QueueItemInfo.qml" line="252"/>
-        <source>Visit website</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="getiplay-cover_programmes_completed_line1">
         <location filename="../qml/cover/CoverPage.qml" line="69"/>
         <source>Programmes</source>
@@ -290,22 +211,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-proglisttv_title">
-        <location filename="../qml/pages/MainPage.qml" line="40"/>
+        <location filename="../qml/pages/MainPage.qml" line="39"/>
         <source>BBC TV Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-proglistradio_title">
-        <location filename="../qml/pages/MainPage.qml" line="46"/>
+        <location filename="../qml/pages/MainPage.qml" line="45"/>
         <source>BBC Radio Programmes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-queue_title">
-        <location filename="../qml/pages/MainPage.qml" line="52"/>
+        <location filename="../qml/pages/MainPage.qml" line="51"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="getiplay-log_title">
-        <location filename="../qml/pages/MainPage.qml" line="57"/>
+        <location filename="../qml/pages/MainPage.qml" line="56"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -632,6 +553,91 @@
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message id="getiplay-title">
+        <location filename="../qml/GetiPlay.qml" line="205"/>
+        <source>harbour-getiplay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_unqueued">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="50"/>
+        <source>Not queued for download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_error">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="55"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_remote">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="60"/>
+        <source>Queued for download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_downloading">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="65"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_local">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="70"/>
+        <source>Downloaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_deleted">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="77"/>
+        <source>File deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_status_error">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="82"/>
+        <source>Unexpected error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem-title">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="109"/>
+        <source>Queue Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_episode">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="127"/>
+        <source>Episode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_channel">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="137"/>
+        <source>Channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_date_available">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="147"/>
+        <source>Date:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueitem_date_unknown">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="149"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_status">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="159"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_play">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="229"/>
+        <source>Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_launch">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="246"/>
+        <source>Launch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="getiplay-queueinfo_website">
+        <location filename="../qml/pages/QueueItemInfo.qml" line="257"/>
+        <source>Website</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
The main change is to allow control of both audio and video via the
lock screen using the Mpris player. The full changes are:

1. Mpris control of audio and video.
2. Improve config file import/export lifecycle.
3. Fix queue removal off-by-one bug.
4. Improve the button layout on the queue info screen.

Fixes #46.